### PR TITLE
Remove close button from DialogContent

### DIFF
--- a/LearnQuake/src/components/ui/dialog.tsx
+++ b/LearnQuake/src/components/ui/dialog.tsx
@@ -42,10 +42,6 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));


### PR DESCRIPTION
Deleted the close button from the DialogContent component in dialog.tsx. This change may be intended to simplify the dialog UI or move close functionality elsewhere.